### PR TITLE
test: BerExp precision known-answer vectors

### DIFF
--- a/falcon-rust/Cargo.toml
+++ b/falcon-rust/Cargo.toml
@@ -26,6 +26,7 @@ shake = "0.1.0"
 falcon-profiler = { version = "0.3.0", path = "../falcon-profiler" }
 
 [dev-dependencies]
+serde_json = "1.0"
 proptest = "1.11.0"
 proptest-derive = "0.7.0"
 arbitrary = "1.4.2"

--- a/falcon-rust/src/samplerz.rs
+++ b/falcon-rust/src/samplerz.rs
@@ -467,6 +467,63 @@ mod test {
         );
     }
 
+    /// The 20 published BerExp precision vectors from
+    /// https://github.com/spartan8806/falcon-sampler-kat (`vectors/berexp.json`, vendored).
+    ///
+    /// These test the ACCEPTANCE-PROBABILITY PRECISION of `approx_exp`, not conformance: the Falcon
+    /// spec stipulates no minimum precision, and the ~2^-40 bar comes from the security analyses
+    /// (Prest'17, HPRR'19), so falling below it invalidates a proof precondition rather than
+    /// violating the spec. Each vector places the drawn value inside the window between `z` and
+    /// `z*(1 +/- 2^-40)`, which makes the accept/reject answer a direct measurement of whether
+    /// `approx_exp` meets that bar. Expected answers are derived from PQClean falcon-512 `clean`.
+    ///
+    /// Both error directions are covered (10 vectors each). The pre-fix FixedPoint64 path errs OVER
+    /// at x = 0.05 and UNDER at x = 0.35 in the same build, so a one-sided set would have missed
+    /// half of them -- which is the mistake GHSA-25rm-9wvm-m38v was about.
+    ///
+    /// Only the first 7 bytes of each vector's stream are used, because that is what `ber_exp`
+    /// consumes. Nothing is lost: the comparison walks the stream MSB-first and stops at the first
+    /// byte differing from `z`, which across all 20 vectors is byte index 4 or 5.
+    #[test]
+    fn berexp_precision_kats_falcon_sampler_kat() {
+        let raw = include_str!("../vectors/berexp.json");
+        let doc: serde_json::Value = serde_json::from_str(raw).expect("berexp.json parses");
+        let sets = doc["parameter_sets"]
+            .as_object()
+            .expect("parameter_sets is an object");
+
+        let mut checked = 0usize;
+        for (set_name, set) in sets {
+            for (i, v) in set["vectors"]
+                .as_array()
+                .expect("vectors is an array")
+                .iter()
+                .enumerate()
+            {
+                // x and ccs are strings in the file on purpose -- exact decimals that must not pick
+                // up a round trip through a JSON parser's float.
+                let x: f64 = v["x"].as_str().unwrap().parse().unwrap();
+                let ccs: f64 = v["ccs"].as_str().unwrap().parse().unwrap();
+                let expected = v["reference_accepts"].as_bool().unwrap();
+
+                let stream = hex::decode(v["bytes"].as_str().unwrap()).unwrap();
+                let bytes: [u8; 7] = stream[..7].try_into().unwrap();
+
+                let got = ber_exp(FixedPoint128::from(x), FixedPoint128::from(ccs), bytes);
+                assert_eq!(
+                    got,
+                    expected,
+                    "{set_name} vector {i} (x = {x}): disagrees with reference -- {}",
+                    v["flips_if"].as_str().unwrap_or("")
+                );
+                checked += 1;
+            }
+        }
+
+        // A vector file that silently lost its contents would otherwise pass vacuously.
+        assert_eq!(checked, 20, "expected 20 published vectors, ran {checked}");
+    }
+
     #[test]
     fn endianness() {
         let bytes: [u8; 9] = rng().random();

--- a/falcon-rust/vectors/berexp.json
+++ b/falcon-rust/vectors/berexp.json
@@ -1,0 +1,261 @@
+{
+  "format": "falcon-sampler-kat.berexp.v1",
+  "generated_against": "PQClean falcon-512 clean (sign.c BerExp, fpr.c fpr_expm_p63)",
+  "discrimination_window": "2^-40 relative error in exp() -- the window THESE VECTORS are built at (u_drawn sits z>>40 from z_reference). Not a figure from any paper.",
+  "derived_requirement": "HPRR'19 (eprint 2019/1411) sect. 5 derives ~2^-43 for Falcon; Prest'17 (eprint 2017/480) sect. 3.3 gives delta <= 2^-37 for lambda <= 256. 2^-43 is STRICTER than the window above, so an implementation between 2^-40 and 2^-43 passes these vectors while sitting under the derived requirement.",
+  "note": "The Falcon specification stipulates no precision floor. These vectors test the premise the security proof requires, not a spec conformance requirement. A pass means 'not catastrophically under-provisioned', NOT 'meets HPRR'19'.",
+  "parameter_sets": {
+    "Falcon-512": {
+      "sigma_min": "1.277833697",
+      "ccs_used": "0.7099076094444444",
+      "vectors": [
+        {
+          "x": "0.05",
+          "ccs": "0.7099076094444444",
+          "bytes": "acdf7a6b994c3e32",
+          "z_reference": "0xacdf7a6b99f91dad",
+          "u_drawn": "0xacdf7a6b994c3e32",
+          "reference_accepts": true,
+          "discriminates_at": "2^-40",
+          "flips_if": "exp() under-computes by more than 2^-40",
+          "s": 0,
+          "r": 0.05
+        },
+        {
+          "x": "0.05",
+          "ccs": "0.7099076094444444",
+          "bytes": "acdf7a6b9aa5fd27",
+          "z_reference": "0xacdf7a6b99f91dad",
+          "u_drawn": "0xacdf7a6b9aa5fd27",
+          "reference_accepts": false,
+          "discriminates_at": "2^-40",
+          "flips_if": "exp() over-computes by more than 2^-40",
+          "s": 0,
+          "r": 0.05
+        },
+        {
+          "x": "0.2000001676183812",
+          "ccs": "0.7099076094444444",
+          "bytes": "94cb0965940ab9bf",
+          "z_reference": "0x94cb0965949f84c9",
+          "u_drawn": "0x94cb0965940ab9bf",
+          "reference_accepts": true,
+          "discriminates_at": "2^-40",
+          "flips_if": "exp() under-computes by more than 2^-40",
+          "s": 0,
+          "r": 0.2000001676183812
+        },
+        {
+          "x": "0.2000001676183812",
+          "ccs": "0.7099076094444444",
+          "bytes": "94cb096595344fd2",
+          "z_reference": "0x94cb0965949f84c9",
+          "u_drawn": "0x94cb096595344fd2",
+          "reference_accepts": false,
+          "discriminates_at": "2^-40",
+          "flips_if": "exp() over-computes by more than 2^-40",
+          "s": 0,
+          "r": 0.2000001676183812
+        },
+        {
+          "x": "0.35",
+          "ccs": "0.7099076094444444",
+          "bytes": "801143be0de70f51",
+          "z_reference": "0x801143be0e672095",
+          "u_drawn": "0x801143be0de70f51",
+          "reference_accepts": true,
+          "discriminates_at": "2^-40",
+          "flips_if": "exp() under-computes by more than 2^-40",
+          "s": 0,
+          "r": 0.35
+        },
+        {
+          "x": "0.35",
+          "ccs": "0.7099076094444444",
+          "bytes": "801143be0ee731d8",
+          "z_reference": "0x801143be0e672095",
+          "u_drawn": "0x801143be0ee731d8",
+          "reference_accepts": false,
+          "discriminates_at": "2^-40",
+          "flips_if": "exp() over-computes by more than 2^-40",
+          "s": 0,
+          "r": 0.35
+        },
+        {
+          "x": "0.5",
+          "ccs": "0.7099076094444444",
+          "bytes": "6e3a89ec9b00cf55",
+          "z_reference": "0x6e3a89ec9b6f09df",
+          "u_drawn": "0x6e3a89ec9b00cf55",
+          "reference_accepts": true,
+          "discriminates_at": "2^-40",
+          "flips_if": "exp() under-computes by more than 2^-40",
+          "s": 0,
+          "r": 0.5
+        },
+        {
+          "x": "0.5",
+          "ccs": "0.7099076094444444",
+          "bytes": "6e3a89ec9bdd4468",
+          "z_reference": "0x6e3a89ec9b6f09df",
+          "u_drawn": "0x6e3a89ec9bdd4468",
+          "reference_accepts": false,
+          "discriminates_at": "2^-40",
+          "flips_if": "exp() over-computes by more than 2^-40",
+          "s": 0,
+          "r": 0.5
+        },
+        {
+          "x": "0.65",
+          "ccs": "0.7099076094444444",
+          "bytes": "5edfebe0d56fefa7",
+          "z_reference": "0x5edfebe0d5cecf93",
+          "u_drawn": "0x5edfebe0d56fefa7",
+          "reference_accepts": true,
+          "discriminates_at": "2^-40",
+          "flips_if": "exp() under-computes by more than 2^-40",
+          "s": 0,
+          "r": 0.65
+        },
+        {
+          "x": "0.65",
+          "ccs": "0.7099076094444444",
+          "bytes": "5edfebe0d62daf7e",
+          "z_reference": "0x5edfebe0d5cecf93",
+          "u_drawn": "0x5edfebe0d62daf7e",
+          "reference_accepts": false,
+          "discriminates_at": "2^-40",
+          "flips_if": "exp() over-computes by more than 2^-40",
+          "s": 0,
+          "r": 0.65
+        }
+      ]
+    },
+    "Falcon-1024": {
+      "sigma_min": "1.298280334",
+      "ccs_used": "0.7212668522222222",
+      "vectors": [
+        {
+          "x": "0.05",
+          "ccs": "0.7212668522222222",
+          "bytes": "afa39c5daa93fae8",
+          "z_reference": "0xafa39c5dab439e85",
+          "u_drawn": "0xafa39c5daa93fae8",
+          "reference_accepts": true,
+          "discriminates_at": "2^-40",
+          "flips_if": "exp() under-computes by more than 2^-40",
+          "s": 0,
+          "r": 0.05
+        },
+        {
+          "x": "0.05",
+          "ccs": "0.7212668522222222",
+          "bytes": "afa39c5dabf34221",
+          "z_reference": "0xafa39c5dab439e85",
+          "u_drawn": "0xafa39c5dabf34221",
+          "reference_accepts": false,
+          "discriminates_at": "2^-40",
+          "flips_if": "exp() over-computes by more than 2^-40",
+          "s": 0,
+          "r": 0.05
+        },
+        {
+          "x": "0.2000001676183812",
+          "ccs": "0.7212668522222222",
+          "bytes": "972c882feac145ea",
+          "z_reference": "0x972c882feb587273",
+          "u_drawn": "0x972c882feac145ea",
+          "reference_accepts": true,
+          "discriminates_at": "2^-40",
+          "flips_if": "exp() under-computes by more than 2^-40",
+          "s": 0,
+          "r": 0.2000001676183812
+        },
+        {
+          "x": "0.2000001676183812",
+          "ccs": "0.7212668522222222",
+          "bytes": "972c882febef9efb",
+          "z_reference": "0x972c882feb587273",
+          "u_drawn": "0x972c882febef9efb",
+          "reference_accepts": false,
+          "discriminates_at": "2^-40",
+          "flips_if": "exp() over-computes by more than 2^-40",
+          "s": 0,
+          "r": 0.2000001676183812
+        },
+        {
+          "x": "0.35",
+          "ccs": "0.7212668522222222",
+          "bytes": "821ddcb5f49207ee",
+          "z_reference": "0x821ddcb5f51425cb",
+          "u_drawn": "0x821ddcb5f49207ee",
+          "reference_accepts": true,
+          "discriminates_at": "2^-40",
+          "flips_if": "exp() under-computes by more than 2^-40",
+          "s": 0,
+          "r": 0.35
+        },
+        {
+          "x": "0.35",
+          "ccs": "0.7212668522222222",
+          "bytes": "821ddcb5f59643a7",
+          "z_reference": "0x821ddcb5f51425cb",
+          "u_drawn": "0x821ddcb5f59643a7",
+          "reference_accepts": false,
+          "discriminates_at": "2^-40",
+          "flips_if": "exp() over-computes by more than 2^-40",
+          "s": 0,
+          "r": 0.35
+        },
+        {
+          "x": "0.5",
+          "ccs": "0.7212668522222222",
+          "bytes": "6ffe10656823c4e6",
+          "z_reference": "0x6ffe10656893c2f7",
+          "u_drawn": "0x6ffe10656823c4e6",
+          "reference_accepts": true,
+          "discriminates_at": "2^-40",
+          "flips_if": "exp() under-computes by more than 2^-40",
+          "s": 0,
+          "r": 0.5
+        },
+        {
+          "x": "0.5",
+          "ccs": "0.7212668522222222",
+          "bytes": "6ffe10656903c107",
+          "z_reference": "0x6ffe10656893c2f7",
+          "u_drawn": "0x6ffe10656903c107",
+          "reference_accepts": false,
+          "discriminates_at": "2^-40",
+          "flips_if": "exp() over-computes by more than 2^-40",
+          "s": 0,
+          "r": 0.5
+        },
+        {
+          "x": "0.65",
+          "ccs": "0.7212668522222222",
+          "bytes": "60648d84f794586b",
+          "z_reference": "0x60648d84f7f4bcf9",
+          "u_drawn": "0x60648d84f794586b",
+          "reference_accepts": true,
+          "discriminates_at": "2^-40",
+          "flips_if": "exp() under-computes by more than 2^-40",
+          "s": 0,
+          "r": 0.65
+        },
+        {
+          "x": "0.65",
+          "ccs": "0.7212668522222222",
+          "bytes": "60648d84f8552186",
+          "z_reference": "0x60648d84f7f4bcf9",
+          "u_drawn": "0x60648d84f8552186",
+          "reference_accepts": false,
+          "discriminates_at": "2^-40",
+          "flips_if": "exp() over-computes by more than 2^-40",
+          "s": 0,
+          "r": 0.65
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Adds the 20 published BerExp precision vectors as a unit test, per your offer in #8.

**What they test.** Acceptance-probability precision of `approx_exp`, not conformance. The Falcon
spec stipulates no minimum precision — the ~2⁻⁴⁰ bar comes from Prest'17 and HPRR'19, so falling
below it invalidates a proof precondition rather than violating the spec. Each vector places the
drawn value inside the window between `z` and `z·(1 ± 2⁻⁴⁰)`, which makes the accept/reject answer a
direct measurement of whether `approx_exp` meets that bar. Expected answers derive from PQClean
falcon-512 `clean`.

Both error directions are covered, ten vectors each. `v0.1.3` errs **over** at `x = 0.05` and
**under** at `x = 0.35` in the same build, so a one-sided set would have missed half of them — the
same one-sided-test mistake GHSA-25rm-9wvm-m38v was about.

**Verified**
- 20/20 pass on `v0.3.0`.
- Inverting a vector's published answer makes the test fail — it can actually go red, which felt like
  the minimum bar given what the vectors are for.
- Full lib suite 168/168.
- I could not run `cargo fmt --check` or `clippy` — neither is installed in my toolchain, so treat
  formatting as unverified. What I could check mechanically: no line I added exceeds 100 columns
  (`samplerz.rs` already has 22 that do, all pre-existing). If CI flags anything, say the word.

**One thing for you to decide.** Reading `berexp.json` at test time needs `serde_json` as a
dev-dependency, which the crate doesn't currently have. The alternative is a checked-in `const` table
generated from the JSON — no new dependency, at the cost of a generation step to keep honest. This PR
does it the way you described in #8; I'm happy to switch to the zero-dependency version instead, and
would rather you pick than assume.

**Notes on the implementation**
- The test lives in `samplerz.rs`'s `#[cfg(test)]` module because `ber_exp` is private. Driving it
  through the public API would exercise the sampler plumbing rather than the arithmetic.
- Only the first 7 bytes of each stream are used, matching `ber_exp`'s buffer. Nothing is lost: the
  comparison walks MSB-first and stops at the first byte differing from `z`, which across all 20
  vectors is byte index 4 or 5. Noted in a comment so it doesn't read as a dropped byte.
- `berexp.json` is vendored so the test is hermetic. Source:
  https://github.com/spartan8806/falcon-sampler-kat

Separately, I mentioned a small out-of-bounds index in `ber_exp` in #8 — not touched here, since
that's a fix rather than a test and it's your call how to handle it.
