### PR TITLE
fix: out-of-bounds index in ber_exp's comparison loop

### DIFF
--- a/falcon-rust/src/samplerz.rs
+++ b/falcon-rust/src/samplerz.rs
@@ -85,9 +85,14 @@ fn ber_exp(x: FixedPoint128, ccs: FixedPoint128, random_bytes: [u8; 7]) -> bool 
     let shamt = usize::min(s, 63);
     let z = ((((approx_exp(r, ccs) as u128) << 1) - 1) >> shamt) as u64;
     let mut w = 0i16;
-    for (index, i) in (0..64).step_by(8).rev().enumerate() {
-        let byte = random_bytes[index];
-        w = (byte as i16) - (((z >> i) & 0xff) as i16);
+    // Iterate the buffer itself, deriving the shift from the index. The previous form iterated
+    // `(0..64).step_by(8).rev()`, which yields EIGHT shifts against a SEVEN-byte buffer, so a draw
+    // whose leading bytes all tie with `z` indexed `random_bytes[7]` and panicked. Driving the loop
+    // from the array makes the bound hold by construction, and it follows automatically if the
+    // buffer width ever changes.
+    for (index, byte) in random_bytes.iter().enumerate() {
+        let shift = 8 * (random_bytes.len() - index);
+        w = (*byte as i16) - (((z >> shift) & 0xff) as i16);
         if w != 0 {
             break;
         }
@@ -465,6 +470,38 @@ mod test {
             ber_exp(x, ccs, bytes),
             "ber_exp regression: acceptance decision flipped"
         );
+    }
+
+    /// Regression test for an out-of-bounds index in `ber_exp`.
+    ///
+    /// The comparison loop iterated `(0..64).step_by(8).rev()` — eight shifts — while indexing a
+    /// seven-byte buffer, so `random_bytes[7]` was read whenever the first seven bytes all tied with
+    /// the corresponding bytes of `z`. From the sampler's own RNG that happens with probability
+    /// about 2^-56, which is why it was never observed; it is reachable deterministically here by
+    /// constructing the tying draw directly.
+    ///
+    /// Behaviour is otherwise unchanged: every decision was already made from the first seven bytes,
+    /// because the eighth iteration could only ever panic rather than return.
+    #[test]
+    fn ber_exp_all_bytes_tie_does_not_panic() {
+        let x = FixedPoint128::from(0.05_f64);
+        let ccs = FixedPoint128::from(0.709_907_609_444_444_4_f64);
+
+        // Reconstruct z exactly as ber_exp does.
+        let s = (x / FixedPoint128::LN_2).trunc() as usize;
+        let r = x - FixedPoint128::LN_2 * FixedPoint128::from(s as i32);
+        let shamt = usize::min(s, 63);
+        let z = ((((approx_exp(r, ccs) as u128) << 1) - 1) >> shamt) as u64;
+
+        // Every available byte equals z's byte at the same position, so the loop never breaks early
+        // and runs to the end of the buffer.
+        let mut bytes = [0u8; 7];
+        for (index, byte) in bytes.iter_mut().enumerate() {
+            *byte = ((z >> (8 * (7 - index))) & 0xff) as u8;
+        }
+
+        // Pre-fix this panicked with "index out of bounds: the len is 7 but the index is 7".
+        assert!(!ber_exp(x, ccs, bytes), "all bytes tie, so w == 0 and the draw is rejected");
     }
 
     /// The 20 published BerExp precision vectors from


### PR DESCRIPTION
The out-of-bounds index from #8, as a separate PR so it can be scrutinised and cited on its own.

**The bug.** The comparison loop iterated `(0..64).step_by(8).rev()` — eight shifts — while indexing
a seven-byte buffer:

```rust
for (index, i) in (0..64).step_by(8).rev().enumerate() {
    let byte = random_bytes[index];   // index reaches 7; len is 7
```

`random_bytes[7]` is read whenever the first seven bytes all tie with the corresponding bytes of `z`.
From the sampler's own RNG that is about 2^-56 per call, and a caller cannot steer it since `sign()`
draws internally — which is why it has never been seen.

**The fix.** Drive the loop from the array rather than an independent range, so the bound holds by
construction and the shifts follow automatically if the buffer width ever changes.

**No input-output change**, which I believe is the condition you had in mind for a minor bump. The
shifts are still 56 down to 8. Every decision was already being made from the first seven bytes,
because the eighth iteration could only panic rather than return — so there is no draw whose
accept/reject answer differs before and after.

**Regression test.** `ber_exp_all_bytes_tie_does_not_panic` reconstructs `z` the way `ber_exp` does
and builds the tying draw directly, so the condition is reproduced deterministically instead of
waited for. Pre-fix it panics with `index out of bounds: the len is 7 but the index is 7`; post-fix
the draw is rejected, which is what `w == 0` means.

Full lib suite 169/169. The 20 precision vectors from #15 are load-bearing here — an earlier version
of this fix mapped index 0 to shift 48 instead of 56, and the vectors caught it immediately.

**One thing I did not change, for you to decide.** With seven bytes there is no eighth comparison and
no retry loop, so a draw that ties on all seven is rejected. PQClean draws eight bytes and re-draws
when all eight tie. The difference is at 2^-56 and I did not want to fold a behavioural change into a
crash fix — but it is a real difference from the reference, so it is yours to weigh.

**Runtime.** `ber_exp` is on the signing hot path, so I measured rather than assuming. 20M calls,
three runs each, release build, same machine:

| | median | min |
|---|---|---|
| this branch | 55.676 ns/call | 55.557 |
| pre-fix | 55.843 ns/call | 55.063 |

Median delta −0.30%, against a run-to-run spread of ~5% within each version — indistinguishable from
noise. That is the expected result: the comparison loop is a few trivial iterations against
`approx_exp`'s 13-step Horner with 128-bit multiplies, so it is a small fraction of the function
either way. Iterating the slice also drops the bounds check the indexed form needed.

**Timing profile is unchanged.** Both forms `break` on the first byte differing from `z`, so the
trip count is data-dependent in exactly the same way, and to the same degree — the draw is uniform,
so the count is dominated by the randomness rather than by `z`. This is the same shape PQClean uses.
The fix does not make the function more or less constant-time; I mention it only because "I changed a
loop in a sampler" deserves the explicit statement.

I could not run `cargo fmt --check` or `clippy`; neither is installed in my toolchain, so treat
formatting as unverified. No line I added exceeds 100 columns.
